### PR TITLE
feat: adds forget function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ Keep in mind that any changes you make within that callback will not be
 reflected when the module is re-evaluated (that's the whole point). So if you
 need to change the callback, then you'll need to restart your server.
 
+#### Forget a value
+
+It might be required to explicitly forget a value if it gets outdated, a memorized
+connection gets lost or memorized instance closes/errors/etc.
+
+```tsx
+import { remember, forget } from '@epic-web/remember'
+
+export const server = remember('server', () =>
+    http.createServer().listen('8080')
+        .on('close', () => forget('server')))
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -17,3 +17,15 @@ export function remember(name, getValue) {
 	}
 	return thusly.__remember_epic_web.get(name)
 }
+
+/**
+ * Forgets a remembered value by a given name. Does not throw if the name doesn't exist.
+ *
+ * @param {string} name - The name under which the value was remembered.
+ * @return {boolean} - A remembered value existed and has been forgotten.
+ */
+export function forget(name) {
+	const thusly = globalThis
+	thusly.__remember_epic_web ??= new Map()
+	return thusly.__remember_epic_web.delete(name)
+}

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,5 +1,10 @@
-import { remember } from './index.js'
-import { expect, test } from 'bun:test'
+import { remember, forget } from './index.js'
+import { expect, test, beforeEach } from 'bun:test'
+
+beforeEach(() => {
+	// ensure global var empty before each test!
+	delete globalThis.__remember_epic_web
+})
 
 // would use mock, but... https://twitter.com/kentcdodds/status/1700718653438931049
 test('remember', () => {
@@ -10,4 +15,18 @@ test('remember', () => {
 	returnValue = Symbol('bud')
 	// because the name and getValue did not change, the value is remembered
 	expect(remember('what is in a name', getValue)).toBe(rose)
+})
+
+test('forget', () => {
+	// nothing remembered yet, trying to forget will "fail"
+	expect(forget('what is in a name')).toBe(false)
+	const rose = Symbol('rose')
+	let returnValue = rose
+	const getValue = () => returnValue
+	expect(remember('what is in a name', getValue)).toBe(rose)
+	// remembered value will be found and forgotten
+	expect(forget('what is in a name')).toBe(true)
+	const bud = returnValue = Symbol('bud')
+	// because the name has been forgotten, we should get the "new" value
+	expect(remember('what is in a name', getValue)).toBe(bud)
 })


### PR DESCRIPTION
Hello @kentcdodds,

as I need to remember a HttpServer instance and clear that instance from "memory" if the server shuts down unexpectedly, I could make good use of a "forget" function to clear a specific value from "memory".

The code was created for our project anyway, so I thought I'll offer it to you as well, to extend the package.
Hope you like it.

Regards
Ruben